### PR TITLE
Fix checkbox background image so it is not repeated.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ deploy:
   provider: npm
   email: d2ltravisdeploy@d2l.com
   api_key:
-    secure: F9PdYmFKwStPC7zVWBjYMB7AsO3/nIhvMkcTNEo8V40frb6do1rBMOm/GwYahjuHWsv4YYSuYsQ+tPZnAU5KiUB68m7LxNa0eyZp2sPV7wgybJwTsK9ItUCtmA99FTYIeAl78iZOUO9taH2TjFCZLZy+xxbE2ggp6wxwNAD3n2U=
+    secure: VZC+cBM+zoaQH/1KfgHvMXpUDnsMzN9riyxE6ZskrZ/fGOqYHxsujeN66cIhhgrNWLglPYK53Py8wVNalt3bmmXHOCZ+IEMJW8r9EgP0BbSkL5vY/elQe6YIjFhQl6Vn9CbrY4Tr4cTL3bu/MEVQGfeqQ4roBQgYcXL2Zh10aPk=
   on:
     tags: true
     all_branches: true

--- a/input-checkbox.scss
+++ b/input-checkbox.scss
@@ -2,6 +2,7 @@
 @import 'input-icons.scss';
 
 @mixin vui-input-checkbox() {
+	background-size: 22px 22px;
 	@include _vui-input-checkbox-radio-helper(
 		checkbox,
 		$vui-checkbox,


### PR DESCRIPTION
This change prevents checkmark image in checkboxes from being repeated on Windows/Chrome.

It also results in better rendering of checkmark on Mac/Chrome (more crisp, not fuzzy).
