### PR TITLE
GAUD-9569: remove images-to-variables

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
   "devDependencies": {
     "autoprefixer": "^6.3.2",
     "csslint-next": "^1.1.1",
-    "images-to-variables": "^0.3.0",
     "node-sass": "^3.4.2",
     "phantomjs-prebuilt": "^2.1.4",
     "postcss-cli": "^2.5.1",


### PR DESCRIPTION
Temporarily un-archived this repo so that we can remove the `images-to-variables` dependency, which I'd like to graveyard. This repo isn't using it and hasn't for quite some time.